### PR TITLE
ci: update download-artifact for Node 24

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,7 @@ runs:
   steps:
     - name: Download - 1st attempt
       id: download1
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v7
       with:
         name: ${{ inputs.name }}
         path: ${{ inputs.path }}
@@ -20,7 +20,7 @@ runs:
     - name: Download - 2nd attempt
       id: download2
       if: steps.download1.outcome == 'failure'
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v7
       with:
         name: ${{ inputs.name }}
         path: ${{ inputs.path }}
@@ -28,7 +28,7 @@ runs:
     - name: Download - 3rd attempt
       id: download3
       if: steps.download2.outcome == 'failure'
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v7
       with:
         name: ${{ inputs.name }}
         path: ${{ inputs.path }}


### PR DESCRIPTION
Updates actions/download-artifact from v4 to v7 to avoid Node.js 20 deprecation warnings.